### PR TITLE
Add theme toggle button styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -231,6 +231,35 @@ section .title::after{
     filter: brightness(90%);
 }
 
+/* theme toggle button */
+#theme-toggle {
+    margin-left: 10px;
+    padding: 8px 12px;
+    background: #fff;
+    color: #111;
+    border: 2px solid #111;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+#theme-toggle:hover {
+    background: #009B4D;
+    color: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+    #theme-toggle {
+        background: #333;
+        color: #fff;
+        border-color: #fff;
+    }
+
+    #theme-toggle:hover {
+        background: #555;
+    }
+}
+
 
 /* home section styling */
 .home{


### PR DESCRIPTION
## Summary
- style `#theme-toggle` button in `styles.css`
- support light and dark mode for the button

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844178c43a48320836150e53c2ddb28